### PR TITLE
Garbage Collection Profiler

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -127,12 +127,12 @@ function take_heap_snapshot(io)
     ccall(:jl_gc_take_heap_snapshot, Cvoid, (Ptr{Cvoid},), (io::IOStream).handle::Ptr{Cvoid})
 end
 
-function start_garbage_profile()
-    ccall(:jl_start_garbage_profile, Cvoid, ())
+function start_garbage_profile(io)
+    ccall(:jl_start_garbage_profile, Cvoid, (Ptr{Cvoid},), io.handle)
 end
 
-function finish_and_write_garbage_profile(io)
-    ccall(:jl_finish_and_write_garbage_profile, Cvoid, (Ptr{Cvoid},), io.handle)
+function stop_garbage_profile()
+    ccall(:jl_stop_garbage_profile, Cvoid, ())
 end
 
 function enable_finalizers()

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -127,6 +127,10 @@ function take_heap_snapshot(io)
     ccall(:jl_gc_take_heap_snapshot, Cvoid, (Ptr{Cvoid},), (io::IOStream).handle::Ptr{Cvoid})
 end
 
+function set_garbage_output_stream(io)
+    ccall(:jl_set_garbage_output_stream, Cvoid, (Ptr{Cvoid},), io.handle)
+end
+
 function enable_finalizers()
     Base.@inline
     ccall(:jl_gc_enable_finalizers_internal, Cvoid, ())

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -127,8 +127,8 @@ function take_heap_snapshot(io)
     ccall(:jl_gc_take_heap_snapshot, Cvoid, (Ptr{Cvoid},), (io::IOStream).handle::Ptr{Cvoid})
 end
 
-function set_garbage_output_stream(io)
-    ccall(:jl_set_garbage_output_stream, Cvoid, (Ptr{Cvoid},), io.handle)
+function set_mem_event_output_stream(io)
+    ccall(:jl_set_mem_event_output_stream, Cvoid, (Ptr{Cvoid},), io.handle)
 end
 
 function enable_finalizers()

--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -127,8 +127,12 @@ function take_heap_snapshot(io)
     ccall(:jl_gc_take_heap_snapshot, Cvoid, (Ptr{Cvoid},), (io::IOStream).handle::Ptr{Cvoid})
 end
 
-function set_mem_event_output_stream(io)
-    ccall(:jl_set_mem_event_output_stream, Cvoid, (Ptr{Cvoid},), io.handle)
+function start_garbage_profile()
+    ccall(:jl_start_garbage_profile, Cvoid, ())
+end
+
+function finish_and_write_garbage_profile(io)
+    ccall(:jl_finish_and_write_garbage_profile, Cvoid, (Ptr{Cvoid},), io.handle)
 end
 
 function enable_finalizers()

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -804,8 +804,6 @@ JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *dt, const void *data)
     jl_value_t *v = jl_gc_alloc(ct->ptls, nb, bt);
     memcpy(jl_assume_aligned(v, sizeof(void*)), data, nb);
 
-    record_allocated_value(v);
-
     return v;
 }
 
@@ -1290,8 +1288,6 @@ JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args, 
         JL_GC_POP();
     }
 
-    record_allocated_value(jv);
-
     return jv;
 }
 
@@ -1339,8 +1335,6 @@ JL_DLLEXPORT jl_value_t *jl_new_structt(jl_datatype_t *type, jl_value_t *tup)
         set_nth_field(type, jv, i, fi, 0);
     }
     JL_GC_POP();
-
-    record_allocated_value(jv);
 
     return jv;
 }

--- a/src/datatype.c
+++ b/src/datatype.c
@@ -786,6 +786,7 @@ JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *dt, const void *data)
     assert(jl_is_datatype(dt));
     jl_datatype_t *bt = (jl_datatype_t*)dt;
     size_t nb = jl_datatype_size(bt);
+
     // some types have special pools to minimize allocations
     if (nb == 0)               return jl_new_struct_uninit(bt); // returns bt->instance
     if (bt == jl_bool_type)    return (1 & *(int8_t*)data) ? jl_true : jl_false;
@@ -802,6 +803,9 @@ JL_DLLEXPORT jl_value_t *jl_new_bits(jl_value_t *dt, const void *data)
     jl_task_t *ct = jl_current_task;
     jl_value_t *v = jl_gc_alloc(ct->ptls, nb, bt);
     memcpy(jl_assume_aligned(v, sizeof(void*)), data, nb);
+
+    record_allocated_value(v);
+
     return v;
 }
 
@@ -1285,6 +1289,9 @@ JL_DLLEXPORT jl_value_t *jl_new_structv(jl_datatype_t *type, jl_value_t **args, 
         }
         JL_GC_POP();
     }
+
+    record_allocated_value(jv);
+
     return jv;
 }
 
@@ -1332,6 +1339,9 @@ JL_DLLEXPORT jl_value_t *jl_new_structt(jl_datatype_t *type, jl_value_t *tup)
         set_nth_field(type, jv, i, fi, 0);
     }
     JL_GC_POP();
+
+    record_allocated_value(jv);
+
     return jv;
 }
 

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -215,7 +215,14 @@ void _report_gc_started() {
     g_frees_by_type_address.clear();
 }
 
-void _report_gc_finished() {
+void _report_gc_finished(uint64_t pause, gc_num *num) {
+    jl_printf(
+        JL_STDERR,
+        "GC: pause %fms. collected %fMB. %lld allocs total\n",
+        pause/1e6, gc_num.freed/1e6, gc_num.allocd
+    );
+
+    // sort frees
     vector<std::pair<size_t, size_t>> pairs;
     for (auto const &pair : g_frees_by_type_address) {
         pairs.push_back(pair);

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -215,11 +215,13 @@ void _report_gc_started() {
     g_frees_by_type_address.clear();
 }
 
-void _report_gc_finished(uint64_t pause, gc_num *num) {
+// TODO: figure out how to pass all of these in as a struct
+void _report_gc_finished(uint64_t pause, uint64_t freed, uint64_t allocd) {
+    // TODO: figure out how to put in commas
     jl_printf(
         JL_STDERR,
         "GC: pause %fms. collected %fMB. %lld allocs total\n",
-        pause/1e6, gc_num.freed/1e6, gc_num.allocd
+        pause/1e6, freed/1e6, allocd
     );
 
     // sort frees

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -233,13 +233,10 @@ JL_DLLEXPORT void jl_finish_and_write_garbage_profile(JL_STREAM *stream) {
     unordered_map<size_t, size_t> type_address_by_value_address;
     unordered_map<size_t, size_t> frees_by_type_address;
 
-    jl_printf(JL_STDERR, "================== start processing. size of memevents: %d ==============\n", g_mem_events.size());
-
     auto idx = 0;
     for (auto event : g_mem_events) {
         switch (event.kind) {
             case ev_alloc:
-                jl_printf(JL_STDERR, "alloc %p. type: %p\n", event.event.alloc.address, event.event.alloc.type_address);
                 type_address_by_value_address[event.event.alloc.address] = event.event.alloc.type_address;
                 break;
             case ev_free: {
@@ -248,16 +245,13 @@ JL_DLLEXPORT void jl_finish_and_write_garbage_profile(JL_STREAM *stream) {
                 if (type_address == type_address_by_value_address.end()) {
                     continue; // TODO: warn
                 }
-                jl_printf(JL_STDERR, "free %p. type: %p\n", value_address, type_address->second);
                 auto frees = frees_by_type_address.find(type_address->second);
-                // jl_printf(JL_STDERR, "free %p. type: %p, cur: %d\n", value_address, type_address->second, frees->second);
 
                 if (frees == frees_by_type_address.end()) {
                     frees_by_type_address[type_address->second] = 1;
                 } else {
                     frees_by_type_address[type_address->second] = frees->second + 1;
                 }
-                jl_printf(JL_STDERR, "frees[%p] = %d\n", type_address->second, frees_by_type_address[type_address->second]);
                 break;
             }
         }
@@ -266,11 +260,8 @@ JL_DLLEXPORT void jl_finish_and_write_garbage_profile(JL_STREAM *stream) {
 
     // sort frees
 
-    jl_printf(JL_STDERR, "============ start printing. size of frees: %d =================\n", frees_by_type_address.size());
-
     vector<std::pair<size_t, size_t>> pairs;
     for (auto const &pair : frees_by_type_address) {
-        jl_printf(stream, "count: %p: %d\n", pair.first, pair.second);
         pairs.push_back(pair);
     }
     std::sort(pairs.begin(), pairs.end(), pair_cmp);
@@ -341,8 +332,6 @@ void register_type_string(jl_datatype_t *type) {
 
     string type_str = _type_as_string(type);
     g_type_name_by_address[(size_t)type] = type_str;
-
-    jl_printf(JL_STDERR, "register type %p: %s\n", type, type_str.c_str());
 }
 
 void record_allocated_value(jl_value_t *val) {

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -225,7 +225,7 @@ JL_DLLEXPORT void jl_set_mem_event_output_stream(JL_STREAM *stream) {
 
 void report_gc_started() {
     if (mem_event_output_stream) {
-        jl_printf(mem_event_output_stream, "gc_start");
+        jl_printf(mem_event_output_stream, "gc_start\n");
     }
 }
 
@@ -233,7 +233,7 @@ void report_gc_finished() {
     if (!mem_event_output_stream) {
         return;
     }
-    jl_printf(mem_event_output_stream, "gc_finish");
+    jl_printf(mem_event_output_stream, "gc_finish\n");
 }
 
 void record_allocated_value(jl_value_t *val) {
@@ -244,7 +244,7 @@ void record_allocated_value(jl_value_t *val) {
     // TODO: something faster, like a type table
     jl_printf(
         mem_event_output_stream,
-        "alloc,%p,%s",
+        "alloc,%p,%s\n",
         val, _type_as_string(val).c_str()
     );
 }
@@ -256,7 +256,7 @@ void record_freed_value(jl_taggedvalue_t *tagged_val) {
 
     jl_value_t *val = jl_valueof(tagged_val);
 
-    jl_printf(mem_event_output_stream, "free,%p", val);
+    jl_printf(mem_event_output_stream, "free,%p\n", val);
 }
 
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L597-L597

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -186,7 +186,7 @@ void _add_internal_root(HeapSnapshot *snapshot) {
 }
 
 JL_STREAM *garbage_output_stream = 0;
-// TODO: keep map
+unordered_map<jl_datatype_t*, size_t> garbage_by_type;
 
 JL_DLLEXPORT void jl_set_garbage_output_stream(JL_STREAM *stream) {
     garbage_output_stream = stream;
@@ -194,12 +194,47 @@ JL_DLLEXPORT void jl_set_garbage_output_stream(JL_STREAM *stream) {
 
 void report_gc_started() {
     if (garbage_output_stream) {
+        garbage_by_type.clear();
         jl_printf(garbage_output_stream, "==================================\n");
     }
 }
 
 void report_gc_finished() {
-    // TODO: print stats
+    for (auto entry : garbage_by_type) {
+        if (
+            (size_t)entry.first >= 0x0000000020000000 &&
+            (size_t)entry.first->name >= 0x0000000020000000 &&
+            (size_t)entry.first->name->name >= 0x0000000020000000
+        ) {
+            // jl_printf(JL_STDERR, "first: %p\n", entry.first);
+            // jl_printf(JL_STDERR, "first->name: %p\n", entry.first->name);
+            // jl_printf(JL_STDERR, "first->name->name: %p\n", entry.first->name->name);
+            // jl_printf(
+            //     garbage_output_stream,
+            //     "%s: %zu\n",
+            //     jl_symbol_name(entry.first->name->name),
+            //     entry.second
+            // );
+
+            jl_datatype_t *type = entry.first;
+
+            ios_t str_;
+            ios_mem(&str_, 1024);
+            JL_STREAM* str = (JL_STREAM*)&str_;
+
+            jl_static_show(str, (jl_value_t*)type);
+
+            string type_str = string((const char*)str_.buf, str_.size);
+            ios_close(&str_);
+
+            jl_printf(
+                garbage_output_stream,
+                "%s: %zu\n",
+                type_str.c_str(),
+                entry.second
+            );
+        }
+    }
 }
 
 void record_garbage_value(jl_taggedvalue_t *tagged_val) {
@@ -230,20 +265,13 @@ void record_garbage_value(jl_taggedvalue_t *tagged_val) {
             name = jl_string_data(val);
         } else if (jl_is_symbol(val)) {
             name = jl_symbol_name((jl_sym_t*)val);
-        } else if (type != NULL && jl_is_datatype(type)) {
-            auto type_name = type->name;
-            if (type_name != NULL) {
-                auto type_name_name = type_name->name; // wtf!?! how does this segfault??
-                if (type_name_name != NULL) {
-                    name = jl_symbol_name(type_name_name);
-                }
+        } else if ((size_t) type > 0x0000000020000000 && jl_is_datatype(type)) {
+            if (garbage_by_type.find(type) == garbage_by_type.end()) {
+                garbage_by_type[type] = 1;
+            } else {
+                garbage_by_type[type] += 1;
             }
-            
         }
-    }
-
-    if (print && garbage_output_stream) {
-        jl_printf(garbage_output_stream, "freeing %u; type %s\n", tagged_val, name.c_str());
     }
 }
 

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -203,7 +203,7 @@ JL_DLLEXPORT void jl_finish_and_write_garbage_profile(JL_STREAM *stream) {
     for (auto pair : frees_by_type) {
         auto type_str = type_string_cache.find(pair.first);
         if (type_str != type_string_cache.end()) {
-            jl_printf(stream, "%s: %d\n", pair.first, pair.second);
+            jl_printf(stream, "%s: %d\n", type_str->second.c_str(), pair.second);
         }
     }
 }
@@ -273,7 +273,7 @@ void record_freed_value(jl_taggedvalue_t *tagged_val) {
     auto type = value_type_cache[val];
     
     auto frees = frees_by_type.find(type);
-    if (frees != frees_by_type.end()) {
+    if (frees == frees_by_type.end()) {
         frees_by_type[type] = 1;
     } else {
         frees_by_type[type] += 1;

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -222,9 +222,6 @@ void report_gc_finished() {
 }
 
 void record_garbage_value(jl_taggedvalue_t *tagged_val) {
-    // for some reason this segfaults during precompilation
-    // but seems fine in normal execution
-    // so import stuff, then turn on the output stream, then execute
     if (!garbage_output_stream) {
         return;
     }

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -45,6 +45,38 @@ void print_str_escape_json(ios_t *stream, const std::string &s) {
     ios_printf(stream, "\"");
 }
 
+string _type_as_string(jl_value_t *val) {
+    string name = "<missing>";
+
+    if (val == (jl_value_t*)jl_malloc_tag) {
+        return "<malloc>";
+    } else {
+        jl_datatype_t* type = (jl_datatype_t*)jl_typeof(val);
+
+        if ((uintptr_t)type < 4096U || (uintptr_t)val < 4096U) {
+            return "<corrupt>";
+        } else if (type == (jl_datatype_t*)jl_buff_tag) {
+            return "<buffer>";
+        } else if (type == (jl_datatype_t*)jl_malloc_tag) {
+            return "<malloc>";
+        } else if (jl_is_string(val)) {
+            return jl_string_data(val);
+        } else if (jl_is_symbol(val)) {
+            return jl_symbol_name((jl_sym_t*)val);
+        } else if (jl_is_datatype(type)) {
+            ios_t str_;
+            ios_mem(&str_, 10024);
+            JL_STREAM* str = (JL_STREAM*)&str_;
+
+            jl_static_show(str, (jl_value_t*)type);
+
+            string type_str = string((const char*)str_.buf, str_.size);
+            ios_close(&str_);
+
+            return type_str;
+        }
+    }
+}
 
 // Edges
 // "edge_fields":
@@ -185,75 +217,46 @@ void _add_internal_root(HeapSnapshot *snapshot) {
     snapshot->nodes.push_back(internal_root);
 }
 
-JL_STREAM *garbage_output_stream = 0;
-unordered_map<string, size_t> garbage_by_type;
+JL_STREAM *mem_event_output_stream = 0;
 
-JL_DLLEXPORT void jl_set_garbage_output_stream(JL_STREAM *stream) {
-    garbage_output_stream = stream;
+JL_DLLEXPORT void jl_set_mem_event_output_stream(JL_STREAM *stream) {
+    mem_event_output_stream = stream;
 }
 
 void report_gc_started() {
-    if (garbage_output_stream) {
-        garbage_by_type.clear();
-        jl_printf(garbage_output_stream, "==================================\n");
+    if (mem_event_output_stream) {
+        jl_printf(mem_event_output_stream, "gc_start");
     }
 }
 
 void report_gc_finished() {
-    for (auto entry : garbage_by_type) {
-        const auto &type_str = entry.first;
-
-        jl_printf(
-            garbage_output_stream,
-            "%s: %zu\n",
-            type_str.c_str(),
-            entry.second
-        );
+    if (!mem_event_output_stream) {
+        return;
     }
+    jl_printf(mem_event_output_stream, "gc_finish");
 }
 
-void record_garbage_value(jl_taggedvalue_t *tagged_val) {
-    if (!garbage_output_stream) {
+void record_allocated_value(jl_value_t *val) {
+    if (!mem_event_output_stream) {
         return;
     }
 
-    string name = "<missing>";
-    int print = 1;
+    // TODO: something faster, like a type table
+    jl_printf(
+        mem_event_output_stream,
+        "alloc,%p,%s",
+        val, _type_as_string(val).c_str()
+    );
+}
+
+void record_freed_value(jl_taggedvalue_t *tagged_val) {
+    if (!mem_event_output_stream) {
+        return;
+    }
 
     jl_value_t *val = jl_valueof(tagged_val);
-    if (val == (jl_value_t*)jl_malloc_tag) {
-        name = "<malloc>";
-    } else {
-        jl_datatype_t* type = (jl_datatype_t*)jl_typeof(val);
 
-        if ((uintptr_t)type < 4096U || (uintptr_t)val < 4096U) {
-            name = "<corrupt>";
-            print = 0;
-        } else if (type == (jl_datatype_t*)jl_buff_tag) {
-            name = "<buffer>";
-        } else if (type == (jl_datatype_t*)jl_malloc_tag) {
-            name = "<malloc>";
-        } else if (jl_is_string(val)) {
-            name = jl_string_data(val);
-        } else if (jl_is_symbol(val)) {
-            name = jl_symbol_name((jl_sym_t*)val);
-        } else if (jl_is_datatype(type)) {
-            ios_t str_;
-            ios_mem(&str_, 10024);
-            JL_STREAM* str = (JL_STREAM*)&str_;
-
-            jl_static_show(str, (jl_value_t*)type);
-
-            string type_str = string((const char*)str_.buf, str_.size);
-            ios_close(&str_);
-
-            if (garbage_by_type.find(type_str) == garbage_by_type.end()) {
-                garbage_by_type[type_str] = 1;
-            } else {
-                garbage_by_type[type_str] += 1;
-            }
-        }
-    }
+    jl_printf(mem_event_output_stream, "free,%p", val);
 }
 
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L597-L597
@@ -269,6 +272,8 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT {
     string name = "<missing>";
     string node_type = "object";
 
+    // TODO: dedup with _type_as_string
+    // need variant that returns size as well
     if (a == (jl_value_t*)jl_malloc_tag) {
         name = "<malloc>";
     } else {

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -45,39 +45,6 @@ void print_str_escape_json(ios_t *stream, const std::string &s) {
     ios_printf(stream, "\"");
 }
 
-string _type_as_string(jl_value_t *val) {
-    string name = "<missing>";
-
-    if (val == (jl_value_t*)jl_malloc_tag) {
-        return "<malloc>";
-    } else {
-        jl_datatype_t* type = (jl_datatype_t*)jl_typeof(val);
-
-        if ((uintptr_t)type < 4096U || (uintptr_t)val < 4096U) {
-            return "<corrupt>";
-        } else if (type == (jl_datatype_t*)jl_buff_tag) {
-            return "<buffer>";
-        } else if (type == (jl_datatype_t*)jl_malloc_tag) {
-            return "<malloc>";
-        } else if (jl_is_string(val)) {
-            return jl_string_data(val);
-        } else if (jl_is_symbol(val)) {
-            return jl_symbol_name((jl_sym_t*)val);
-        } else if (jl_is_datatype(type)) {
-            ios_t str_;
-            ios_mem(&str_, 10024);
-            JL_STREAM* str = (JL_STREAM*)&str_;
-
-            jl_static_show(str, (jl_value_t*)type);
-
-            string type_str = string((const char*)str_.buf, str_.size);
-            ios_close(&str_);
-
-            return type_str;
-        }
-    }
-}
-
 // Edges
 // "edge_fields":
 //   [ "type", "name_or_index", "to_node" ]
@@ -217,23 +184,77 @@ void _add_internal_root(HeapSnapshot *snapshot) {
     snapshot->nodes.push_back(internal_root);
 }
 
-JL_STREAM *mem_event_output_stream = 0;
+JL_STREAM *mem_event_output_stream = nullptr;
+unordered_map<jl_datatype_t*, size_t> mem_event_type_table;
 
 JL_DLLEXPORT void jl_set_mem_event_output_stream(JL_STREAM *stream) {
     mem_event_output_stream = stream;
 }
 
 void report_gc_started() {
-    if (mem_event_output_stream) {
-        jl_printf(mem_event_output_stream, "gc_start\n");
+    if (!mem_event_output_stream) {
+        return;
     }
+    jl_printf(mem_event_output_stream, "GS\n");
 }
 
 void report_gc_finished() {
     if (!mem_event_output_stream) {
         return;
     }
-    jl_printf(mem_event_output_stream, "gc_finish\n");
+    jl_printf(mem_event_output_stream, "GF\n");
+}
+
+string _type_as_string(jl_value_t *val) {
+    string name = "<missing>";
+
+    if (val == (jl_value_t*)jl_malloc_tag) {
+        return "<malloc>";
+    } else {
+        jl_datatype_t* type = (jl_datatype_t*)jl_typeof(val);
+
+        if ((uintptr_t)type < 4096U || (uintptr_t)val < 4096U) {
+            return "<corrupt>";
+        } else if (type == (jl_datatype_t*)jl_buff_tag) {
+            return "<buffer>";
+        } else if (type == (jl_datatype_t*)jl_malloc_tag) {
+            return "<malloc>";
+        } else if (jl_is_string(val)) {
+            return jl_string_data(val);
+        } else if (jl_is_symbol(val)) {
+            return jl_symbol_name((jl_sym_t*)val);
+        } else if (jl_is_datatype(type)) {
+            ios_t str_;
+            ios_mem(&str_, 10024);
+            JL_STREAM* str = (JL_STREAM*)&str_;
+
+            jl_static_show(str, (jl_value_t*)type);
+
+            string type_str = string((const char*)str_.buf, str_.size);
+            ios_close(&str_);
+
+            return type_str;
+        }
+    }
+}
+
+size_t mem_events_register_type(jl_value_t *val) {
+    if (val == (jl_value_t*)jl_malloc_tag) {
+        return 0;
+    }
+
+    jl_datatype_t* type = (jl_datatype_t*)jl_typeof(val);;
+    auto id = mem_event_type_table.find(type);
+    if (id != mem_event_type_table.end()) {
+        return id->second;
+    }
+
+    string type_str = _type_as_string(val);
+    size_t type_id = mem_event_type_table.size();
+    jl_printf(mem_event_output_stream, "T|%s|%ld\n", type_str.c_str(), type_id);
+    mem_event_type_table[type] = type_id;
+
+    return type_id;
 }
 
 void record_allocated_value(jl_value_t *val) {
@@ -241,12 +262,10 @@ void record_allocated_value(jl_value_t *val) {
         return;
     }
 
+    auto type_id = mem_events_register_type(val);
+
     // TODO: something faster, like a type table
-    jl_printf(
-        mem_event_output_stream,
-        "alloc,%p,%s\n",
-        val, _type_as_string(val).c_str()
-    );
+    jl_printf(mem_event_output_stream, "A|%p|%ld\n", val, type_id);
 }
 
 void record_freed_value(jl_taggedvalue_t *tagged_val) {
@@ -256,7 +275,7 @@ void record_freed_value(jl_taggedvalue_t *tagged_val) {
 
     jl_value_t *val = jl_valueof(tagged_val);
 
-    jl_printf(mem_event_output_stream, "free,%p\n", val);
+    jl_printf(mem_event_output_stream, "F|%p\n", val);
 }
 
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L597-L597

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -203,6 +203,13 @@ void report_gc_finished() {
 }
 
 void record_garbage_value(jl_taggedvalue_t *tagged_val) {
+    // for some reason this segfaults during precompilation
+    // but seems fine in normal execution
+    // so import stuff, then turn on the output stream, then execute
+    if (!garbage_output_stream) {
+        return;
+    }
+
     string name = "<missing>";
     int print = 1;
 
@@ -223,16 +230,15 @@ void record_garbage_value(jl_taggedvalue_t *tagged_val) {
             name = jl_string_data(val);
         } else if (jl_is_symbol(val)) {
             name = jl_symbol_name((jl_sym_t*)val);
-        } else if (jl_is_datatype(type)) {
-            // print full type
-            ios_t str_;
-            ios_mem(&str_, 1024);
-            JL_STREAM* str = (JL_STREAM*)&str_;
-
-            jl_static_show(str, (jl_value_t*)type);
-
-            name = string((const char*)str_.buf, str_.size);
-            ios_close(&str_);
+        } else if (type != NULL && jl_is_datatype(type)) {
+            auto type_name = type->name;
+            if (type_name != NULL) {
+                auto type_name_name = type_name->name; // wtf!?! how does this segfault??
+                if (type_name_name != NULL) {
+                    name = jl_symbol_name(type_name_name);
+                }
+            }
+            
         }
     }
 

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -265,7 +265,7 @@ JL_DLLEXPORT void jl_finish_and_write_garbage_profile(JL_STREAM *stream) {
                 break;
             }
             case ev_type:
-                jl_printf(JL_STDERR, "type %d: %s\n", idx, event.event.type.name);
+                jl_printf(JL_STDERR, "type %d: %p: %s\n", idx, event.event.type.name, event.event.type.name);
                 type_name_by_id[idx] = event.event.type.name;
                 break;
         }
@@ -348,9 +348,10 @@ size_t register_type_string(jl_datatype_t *type) {
 
     g_type_event_index[type] = g_mem_events.size();
 
-    jl_printf(JL_STDERR, "register type %d: %s\n", g_mem_events.size(), event.event.type.name);
+    jl_printf(JL_STDERR, "register type %d: %p, %s\n", g_mem_events.size(), event.event.type.name, event.event.type.name);
 
     g_mem_events.push_back(event);
+    jl_printf(JL_STDERR, "_register type %p, %s\n", g_mem_events.back().event.type.name, g_mem_events.back().event.type.name);
 }
 
 void record_allocated_value(jl_value_t *val) {

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -195,7 +195,7 @@ struct free_event {
     size_t address;
 };
 struct type_event {
-    string name;
+    const char *name;
 };
 struct gc_start_event {};
 struct gc_finish_event {};
@@ -227,7 +227,7 @@ JL_DLLEXPORT void jl_start_garbage_profile() {
     g_type_event_index.clear();
 }
 
-bool pair_cmp(std::pair<jl_datatype_t*, size_t> a, std::pair<jl_datatype_t*, size_t> b) {
+bool pair_cmp(std::pair<size_t, size_t> a, std::pair<size_t, size_t> b) {
     return a.second > b.second;
 }
 
@@ -245,7 +245,7 @@ JL_DLLEXPORT void jl_finish_and_write_garbage_profile(JL_STREAM *stream) {
             case ev_alloc:
                 type_id_by_address[event.event.alloc.address] = event.event.alloc.type_id;
                 break;
-            case ev_free:
+            case ev_free: {
                 auto address = event.event.free.address;
                 auto frees = frees_by_type_id.find(address);
                 if (frees == frees_by_type_id.end()) {
@@ -254,6 +254,7 @@ JL_DLLEXPORT void jl_finish_and_write_garbage_profile(JL_STREAM *stream) {
                     frees_by_type_id[address] = frees->second + 1;
                 }
                 break;
+            }
             case ev_type:
                 type_name_by_id[idx] = event.event.type.name;
                 break;
@@ -262,7 +263,7 @@ JL_DLLEXPORT void jl_finish_and_write_garbage_profile(JL_STREAM *stream) {
     }
 
     // sort frees
-    vector<std::pair<jl_datatype_t*, size_t>> pairs;
+    vector<std::pair<size_t, size_t>> pairs;
     for (auto pair : frees_by_type_id) {
         pairs.push_back(pair);
     }
@@ -333,7 +334,7 @@ size_t register_type_string(jl_datatype_t *type) {
 
     mem_event event;
     event.kind = ev_type;
-    event.event = type_event{type_str};
+    event.event.type = type_event{type_str.c_str()};
 
     g_mem_events.push_back(event);
     g_type_event_index[type] = g_mem_events.size();

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -185,6 +185,62 @@ void _add_internal_root(HeapSnapshot *snapshot) {
     snapshot->nodes.push_back(internal_root);
 }
 
+JL_STREAM *garbage_output_stream = 0;
+// TODO: keep map
+
+JL_DLLEXPORT void jl_set_garbage_output_stream(JL_STREAM *stream) {
+    garbage_output_stream = stream;
+}
+
+void report_gc_started() {
+    if (garbage_output_stream) {
+        jl_printf(garbage_output_stream, "==================================\n");
+    }
+}
+
+void report_gc_finished() {
+    // TODO: print stats
+}
+
+void record_garbage_value(jl_taggedvalue_t *tagged_val) {
+    string name = "<missing>";
+    int print = 1;
+
+    jl_value_t *val = jl_valueof(tagged_val);
+    if (val == (jl_value_t*)jl_malloc_tag) {
+        name = "<malloc>";
+    } else {
+        jl_datatype_t* type = (jl_datatype_t*)jl_typeof(val);
+
+        if ((uintptr_t)type < 4096U || (uintptr_t)val < 4096U) {
+            name = "<corrupt>";
+            print = 0;
+        } else if (type == (jl_datatype_t*)jl_buff_tag) {
+            name = "<buffer>";
+        } else if (type == (jl_datatype_t*)jl_malloc_tag) {
+            name = "<malloc>";
+        } else if (jl_is_string(val)) {
+            name = jl_string_data(val);
+        } else if (jl_is_symbol(val)) {
+            name = jl_symbol_name((jl_sym_t*)val);
+        } else if (jl_is_datatype(type)) {
+            // print full type
+            ios_t str_;
+            ios_mem(&str_, 1024);
+            JL_STREAM* str = (JL_STREAM*)&str_;
+
+            jl_static_show(str, (jl_value_t*)type);
+
+            name = string((const char*)str_.buf, str_.size);
+            ios_close(&str_);
+        }
+    }
+
+    if (print && garbage_output_stream) {
+        jl_printf(garbage_output_stream, "freeing %u; type %s\n", tagged_val, name.c_str());
+    }
+}
+
 // mimicking https://github.com/nodejs/node/blob/5fd7a72e1c4fbaf37d3723c4c81dce35c149dc84/deps/v8/src/profiler/heap-snapshot-generator.cc#L597-L597
 // returns the index of the new node
 size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT {

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -17,7 +17,7 @@ JL_DLLEXPORT void jl_stop_garbage_profile(void);
 // functions to call from GC when garbage profiling is enabled
 // ---------------------------------------------------------------------
 void _report_gc_started(void);
-void _report_gc_finished(void);
+void _report_gc_finished(uint64_t pause, uint64_t freed, uint64_t allocd);
 void _record_allocated_value(jl_value_t *val);
 void _record_freed_value(jl_taggedvalue_t *tagged_val);
 

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-JL_DLLEXPORT void jl_set_garbage_output_stream(JL_STREAM *stream);
+JL_DLLEXPORT void jl_set_mem_event_output_stream(JL_STREAM *stream);
 void report_gc_started(void);
 void report_gc_finished(void);
 void record_allocated_value(jl_value_t *val);

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -10,12 +10,16 @@
 extern "C" {
 #endif
 
-JL_DLLEXPORT void jl_start_garbage_profile(void);
-JL_DLLEXPORT void jl_finish_and_write_garbage_profile(JL_STREAM *stream);
-void report_gc_started(void);
-void report_gc_finished(void);
-void record_allocated_value(jl_value_t *val);
-void record_freed_value(jl_taggedvalue_t *tagged_val);
+JL_DLLEXPORT void jl_start_garbage_profile(JL_STREAM *stream);
+JL_DLLEXPORT void jl_stop_garbage_profile(void);
+
+// ---------------------------------------------------------------------
+// functions to call from GC when garbage profiling is enabled
+// ---------------------------------------------------------------------
+void _report_gc_started(void);
+void _report_gc_finished(void);
+void _record_allocated_value(jl_value_t *val);
+void _record_freed_value(jl_taggedvalue_t *tagged_val);
 
 // ---------------------------------------------------------------------
 // Functions to call from GC when heap snapshot is enabled
@@ -37,6 +41,19 @@ void _gc_heap_snapshot_record_hidden_edge(jl_value_t *from, size_t bytes) JL_NOT
 
 
 extern int gc_heap_snapshot_enabled;
+extern JL_STREAM *garbage_profile_out; // TODO: replace w/ bool?
+
+static inline void record_allocated_value(jl_value_t *val) {
+    if (__unlikely(garbage_profile_out != 0)) {
+        _record_allocated_value(val);
+    }
+}
+
+static inline void record_freed_value(jl_taggedvalue_t *tagged_val) {
+    if (__unlikely(garbage_profile_out != 0)) {
+        _record_freed_value(tagged_val);
+    }
+}
 
 static inline void gc_heap_snapshot_record_frame_to_object_edge(jl_gcframe_t *from, jl_value_t *to) {
     if (__unlikely(gc_heap_snapshot_enabled)) {

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -10,6 +10,10 @@
 extern "C" {
 #endif
 
+JL_DLLEXPORT void jl_set_garbage_output_stream(JL_STREAM *stream);
+void report_gc_started();
+void report_gc_finished();
+void record_garbage_value(jl_taggedvalue_t *tagged_val);
 
 // ---------------------------------------------------------------------
 // Functions to call from GC when heap snapshot is enabled

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-JL_DLLEXPORT void jl_start_garbage_profile(JL_STREAM *stream);
+JL_DLLEXPORT void jl_start_garbage_profile(ios_t *stream);
 JL_DLLEXPORT void jl_stop_garbage_profile(void);
 
 // ---------------------------------------------------------------------
@@ -41,7 +41,7 @@ void _gc_heap_snapshot_record_hidden_edge(jl_value_t *from, size_t bytes) JL_NOT
 
 
 extern int gc_heap_snapshot_enabled;
-extern JL_STREAM *garbage_profile_out; // TODO: replace w/ bool?
+extern ios_t *garbage_profile_out; // TODO: replace w/ bool?
 
 static inline void record_allocated_value(jl_value_t *val) {
     if (__unlikely(garbage_profile_out != 0)) {

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -10,7 +10,8 @@
 extern "C" {
 #endif
 
-JL_DLLEXPORT void jl_set_mem_event_output_stream(JL_STREAM *stream);
+JL_DLLEXPORT void jl_start_garbage_profile(void);
+JL_DLLEXPORT void jl_finish_and_write_garbage_profile(JL_STREAM *stream);
 void report_gc_started(void);
 void report_gc_finished(void);
 void record_allocated_value(jl_value_t *val);

--- a/src/gc-heap-snapshot.h
+++ b/src/gc-heap-snapshot.h
@@ -11,9 +11,10 @@ extern "C" {
 #endif
 
 JL_DLLEXPORT void jl_set_garbage_output_stream(JL_STREAM *stream);
-void report_gc_started();
-void report_gc_finished();
-void record_garbage_value(jl_taggedvalue_t *tagged_val);
+void report_gc_started(void);
+void report_gc_finished(void);
+void record_allocated_value(jl_value_t *val);
+void record_freed_value(jl_taggedvalue_t *tagged_val);
 
 // ---------------------------------------------------------------------
 // Functions to call from GC when heap snapshot is enabled

--- a/src/gc.c
+++ b/src/gc.c
@@ -1323,7 +1323,7 @@ static jl_taggedvalue_t **sweep_page(jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_t
         while ((char*)v <= lim) {
             int bits = v->bits.gc;
             if (!gc_marked(bits)) {
-                record_garbage_value(v);
+                record_freed_value(v);
                 *pfl = v;
                 pfl = &v->next;
                 pfl_begin = pfl_begin ? pfl_begin : pfl;

--- a/src/gc.c
+++ b/src/gc.c
@@ -3056,7 +3056,7 @@ size_t jl_maxrss(void);
 // Only one thread should be running in this function
 static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
 {
-    report_gc_started();
+    _report_gc_started();
 
     combine_thread_gc_counts(&gc_num);
 
@@ -3247,7 +3247,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     uint64_t gc_end_t = jl_hrtime();
     uint64_t pause = gc_end_t - t0;
 
-    report_gc_finished(); // TODO: pass stats
+    _report_gc_finished(); // TODO: pass stats
     jl_printf(JL_STDERR, "GC: pause %fms. collected %fMB. %lld allocs total\n", pause/1e6, gc_num.freed/1e6, gc_num.allocd);
 
     gc_final_pause_end(t0, gc_end_t);

--- a/src/gc.c
+++ b/src/gc.c
@@ -3247,8 +3247,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     uint64_t gc_end_t = jl_hrtime();
     uint64_t pause = gc_end_t - t0;
 
-    _report_gc_finished(); // TODO: pass stats
-    jl_printf(JL_STDERR, "GC: pause %fms. collected %fMB. %lld allocs total\n", pause/1e6, gc_num.freed/1e6, gc_num.allocd);
+    _report_gc_finished(pause, gc_num);
 
     gc_final_pause_end(t0, gc_end_t);
     gc_time_sweep_pause(gc_end_t, actual_allocd, live_bytes,

--- a/src/gc.c
+++ b/src/gc.c
@@ -1323,41 +1323,7 @@ static jl_taggedvalue_t **sweep_page(jl_gc_pool_t *p, jl_gc_pagemeta_t *pg, jl_t
         while ((char*)v <= lim) {
             int bits = v->bits.gc;
             if (!gc_marked(bits)) {
-                char *name = "<missing>";
-
-                jl_value_t *val = jl_valueof(v);
-                if (val == (jl_value_t*)jl_malloc_tag) {
-                    name = "<malloc>";
-                } else {
-                    jl_datatype_t* type = (jl_datatype_t*)jl_typeof(val);
-
-                    if ((uintptr_t)type < 4096U) {
-                        name = "<corrupt>";
-                    } else if (type == (jl_datatype_t*)jl_buff_tag) {
-                        name = "<buffer>";
-                    } else if (type == (jl_datatype_t*)jl_malloc_tag) {
-                        name = "<malloc>";
-                    } else if (jl_is_string(val)) {
-                        name = jl_string_data(val);
-                    } else if (jl_is_symbol(val)) {
-                        name = jl_symbol_name((jl_sym_t*)val);
-                    } else if (jl_is_datatype(type)) {
-                        // print full type
-                        ios_t str_;
-                        ios_mem(&str_, 1024);
-                        JL_STREAM* str = (JL_STREAM*)&str_;
-
-                        jl_static_show(str, (jl_value_t*)type);
-
-                        name = (char*)str_.buf;
-                        name[str_.size] = '\0';
-
-                        ios_close(&str_);
-                    }
-                }
-
-                jl_printf(JL_STDERR, "freeing %u; type %s\n", v, name);
-
+                record_garbage_value(v);
                 *pfl = v;
                 pfl = &v->next;
                 pfl_begin = pfl_begin ? pfl_begin : pfl;
@@ -3090,6 +3056,8 @@ size_t jl_maxrss(void);
 // Only one thread should be running in this function
 static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
 {
+    report_gc_started();
+
     combine_thread_gc_counts(&gc_num);
 
     jl_gc_mark_cache_t *gc_cache = &ptls->gc_cache;
@@ -3279,6 +3247,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     uint64_t gc_end_t = jl_hrtime();
     uint64_t pause = gc_end_t - t0;
 
+    report_gc_finished(); // TODO: pass stats
     jl_printf(JL_STDERR, "GC: pause %fms. collected %fMB. %lld allocs total\n", pause/1e6, gc_num.freed/1e6, gc_num.allocd);
 
     gc_final_pause_end(t0, gc_end_t);

--- a/src/gc.c
+++ b/src/gc.c
@@ -3243,6 +3243,9 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
 
     uint64_t gc_end_t = jl_hrtime();
     uint64_t pause = gc_end_t - t0;
+
+    jl_printf(JL_STDERR, "GC: pause %fms. collected %fMB. %lld allocs total\n", pause/1e6, gc_num.freed/1e6, gc_num.allocd);
+
     gc_final_pause_end(t0, gc_end_t);
     gc_time_sweep_pause(gc_end_t, actual_allocd, live_bytes,
                         estimate_freed, sweep_full);

--- a/src/gc.c
+++ b/src/gc.c
@@ -3247,7 +3247,7 @@ static int _jl_gc_collect(jl_ptls_t ptls, jl_gc_collection_t collection)
     uint64_t gc_end_t = jl_hrtime();
     uint64_t pause = gc_end_t - t0;
 
-    _report_gc_finished(pause, gc_num);
+    _report_gc_finished(pause, gc_num.freed, gc_num.allocd);
 
     gc_final_pause_end(t0, gc_end_t);
     gc_time_sweep_pause(gc_end_t, actual_allocd, live_bytes,

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -5,6 +5,7 @@
 
 #include "options.h"
 #include "julia_locks.h"
+#include "gc-heap-snapshot.h"
 #include <uv.h>
 #if !defined(_WIN32)
 #include <unistd.h>
@@ -362,6 +363,9 @@ STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
         v = jl_gc_big_alloc(ptls, allocsz);
     }
     jl_set_typeof(v, ty);
+
+    record_allocated_value(v);
+
     return v;
 }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -364,7 +364,7 @@ STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
     }
     jl_set_typeof(v, ty);
 
-    record_allocated_value(v);
+    _record_allocated_value(v);
 
     return v;
 }

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -617,18 +617,6 @@ JL_DLLEXPORT jl_value_t *jl_argument_datatype(jl_value_t *argt JL_PROPAGATES_ROO
 
 static int is_globfunction(jl_value_t *v, jl_datatype_t *dv, jl_sym_t **globname_out)
 {
-    if (!dv) {
-        return 0;
-    }
-    if (!dv->name) {
-        return 0;
-    }
-    if (!dv->name->mt) {
-        return 0;
-    }
-    if (!dv->name->mt->name) {
-        return 0;
-    }
     jl_sym_t *globname = dv->name->mt != NULL ? dv->name->mt->name : NULL;
     *globname_out = globname;
     int globfunc = 0;
@@ -773,12 +761,6 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         jl_datatype_t *dv = (jl_datatype_t*)v;
         jl_sym_t *globname;
         int globfunc = is_globfunction(v, dv, &globname);
-        if (!dv->name) {
-            return 0;
-        }
-        if (!dv->name->name) {
-            return 0;
-        }
         jl_sym_t *sym = globfunc ? globname : dv->name->name;
         char *sn = jl_symbol_name(sym);
         size_t quote = 0;

--- a/src/rtutils.c
+++ b/src/rtutils.c
@@ -617,6 +617,18 @@ JL_DLLEXPORT jl_value_t *jl_argument_datatype(jl_value_t *argt JL_PROPAGATES_ROO
 
 static int is_globfunction(jl_value_t *v, jl_datatype_t *dv, jl_sym_t **globname_out)
 {
+    if (!dv) {
+        return 0;
+    }
+    if (!dv->name) {
+        return 0;
+    }
+    if (!dv->name->mt) {
+        return 0;
+    }
+    if (!dv->name->mt->name) {
+        return 0;
+    }
     jl_sym_t *globname = dv->name->mt != NULL ? dv->name->mt->name : NULL;
     *globname_out = globname;
     int globfunc = 0;
@@ -761,6 +773,12 @@ static size_t jl_static_show_x_(JL_STREAM *out, jl_value_t *v, jl_datatype_t *vt
         jl_datatype_t *dv = (jl_datatype_t*)v;
         jl_sym_t *globname;
         int globfunc = is_globfunction(v, dv, &globname);
+        if (!dv->name) {
+            return 0;
+        }
+        if (!dv->name->name) {
+            return 0;
+        }
         jl_sym_t *sym = globfunc ? globname : dv->name->name;
         char *sn = jl_symbol_name(sym);
         size_t quote = 0;


### PR DESCRIPTION
Ever seen a `@time` printout like this:
```
5091.986425 seconds (5.59 G allocations: 324.011 GiB, 57.83% gc time, 5.70% compilation time)
```
And wondered what all the memory is that's being allocated and collected? This PR is for you…

It generates a report of how many objects of each type are being freed during each garbage collection.

## Usage

```julia
file = open("gc-profile.csv", "w")
GC.start_garbage_profile(file)

# ... the code you want to profile ...

GC.stop_garbage_profile()
flush(file) # TODO: figure out how to do this from C...
```

## Output

A CSV file with these columns:
* `gc_epoch`: an integer that starts at 0 and increases each time the garbage collector runs
* `type`: type of julia object being freed
* `num_freed` number of that type freed during that GC epoch

e.g.:
```csv
gc_epoch,type,num_freed
1,Foo,5
1,Bar,6
2,Foo,3
3,Bar,2
```

Output is streamed to this file as the program runs.

## Notes

- based on https://github.com/JuliaLang/julia/pull/42286, but doesn't share much code with the heap snapshot mechanism, so could be broken out into its own file & PR.

## Future work

- get stack traces of allocations (especially useful to attribute generic types like `Array{UInt8, 1}`)
- maybe output as PProf memory profile format, like in this article (scroll down to see graphviz output): https://www.freecodecamp.org/news/how-i-investigated-memory-leaks-in-go-using-pprof-on-a-large-codebase-4bec4325e192/
- [ ] is this threadsafe? i.e. can the allocator be called into from multiple threads, which might lead to mutating the hash map concurrently?