### PR TITLE
make the alloc profiler multithreaded

### DIFF
--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -100,10 +100,10 @@ JL_DLLEXPORT struct RawAllocResults jl_stop_alloc_profile() {
     }
 
     return RawAllocResults{
-        combined_allocs.data(),
-        combined_allocs.size(),
-        combined_frees.data(),
-        combined_frees.size()
+        g_combined_results.combined_allocs.data(),
+        g_combined_results.combined_allocs.size(),
+        g_combined_results.combined_frees.data(),
+        g_combined_results.combined_frees.size()
     };
 }
 

--- a/src/gc-alloc-profiler.h
+++ b/src/gc-alloc-profiler.h
@@ -34,7 +34,7 @@ void _report_gc_finished(
     uint64_t pause, uint64_t freed, uint64_t allocd, int full, int recollect
 ) JL_NOTSAFEPOINT;
 JL_DLLEXPORT void jl_start_alloc_profile(int skip_every);
-JL_DLLEXPORT struct RawAllocResults *jl_stop_alloc_profile(void);
+JL_DLLEXPORT struct RawAllocResults jl_stop_alloc_profile(void);
 JL_DLLEXPORT void jl_free_alloc_profile(void);
 
 void _record_allocated_value(jl_value_t *val, size_t size) JL_NOTSAFEPOINT;

--- a/stdlib/AllocProfile/src/AllocProfile.jl
+++ b/stdlib/AllocProfile/src/AllocProfile.jl
@@ -37,8 +37,7 @@ function start(skip_every::Int=0)
 end
 
 function stop()
-    raw_results_ptr = ccall(:jl_stop_alloc_profile, Ptr{RawAllocResults}, ())
-    raw_results = unsafe_load(raw_results_ptr)
+    raw_results = ccall(:jl_stop_alloc_profile, RawAllocResults, ())
     decoded_results = decode(raw_results)
     return decoded_results
 end

--- a/stdlib/AllocProfile/src/AllocProfile.jl
+++ b/stdlib/AllocProfile/src/AllocProfile.jl
@@ -66,7 +66,7 @@ end
 # decoded results
 
 struct Alloc
-    type::Type
+    type::Any
     stacktrace::StackTrace
     size::Int
 end
@@ -85,13 +85,15 @@ const BacktraceCache = Dict{BacktraceEntry,Vector{StackFrame}}
 
 # loading anything below this seems to segfault
 # TODO: find out what's going on
-TYPE_PTR_THRESHOLD = 0x0000000100000000
+TYPE_PTR_LOW_THRESHOLD = 0x0000000100000000
+TYPE_PTR_HIGH_THRESHOLD = 100000000000000
 
-function load_type(ptr::Ptr{Type})::Type
-    if UInt(ptr) < TYPE_PTR_THRESHOLD
-        return Missing
+function load_type(ptr::Ptr{Type})
+    # println("type: $(UInt(ptr))")
+    if TYPE_PTR_LOW_THRESHOLD < UInt(ptr) < TYPE_PTR_HIGH_THRESHOLD
+        return unsafe_pointer_to_objref(ptr)
     end
-    return unsafe_pointer_to_objref(ptr)
+    return Missing
 end
 
 function decode_alloc(cache::BacktraceCache, raw_alloc::RawAlloc)::Alloc

--- a/stdlib/AllocProfile/src/AllocProfile.jl
+++ b/stdlib/AllocProfile/src/AllocProfile.jl
@@ -18,11 +18,6 @@ struct RawAlloc
     size::Csize_t
 end
 
-struct TypeNamePair
-    addr::Csize_t
-    name::Ptr{UInt8}
-end
-
 struct FreeInfo
     type::Ptr{Type}
     count::UInt
@@ -124,11 +119,21 @@ function decode(raw_results::RawAllocResults)::AllocResults
     )
 end
 
+const f = Ref{IOStream}()
+
+function __init__()
+    f[] = open("debug.log", "w")
+end
+
 function load_backtrace(trace::RawBacktrace)::Vector{Ptr{Cvoid}}
+    println(f[], "load_backtrace: trace.data: $(trace.data)")
+    println(f[], "load_backtrace: trace.size: $(trace.size)")
     out = Vector{Ptr{Cvoid}}()
     for i in 1:trace.size
+        println(f[], "  $i")
         push!(out, unsafe_load(trace.data, i))
     end
+
     return out
 end
 

--- a/stdlib/AllocProfile/test/runtests.jl
+++ b/stdlib/AllocProfile/test/runtests.jl
@@ -12,7 +12,7 @@ using AllocProfile
     using Base64
 
     results = AllocProfile.stop()
-    AllocProfile.clear()
+    # AllocProfile.clear()
 
     @test length(results.allocs) > 0
     first_alloc = results.allocs[1]


### PR DESCRIPTION
have one alloc profile per thread; combine 'em at the end

seems to segfault sometimes :(