### PR TITLE
alloc profiler: switch to uniform sampling with rand()

### DIFF
--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -137,8 +137,8 @@ void _record_allocated_value(jl_value_t *val, size_t size) JL_NOTSAFEPOINT {
     }
 
     auto type = (jl_datatype_t*)jl_typeof(val);
-    // TODO: this info is later used when counting frees, but is that
-    // necessary?
+    // Used when counting frees. We can't get type type info then,
+    // because it gets corrupted during garbage collection.
     profile.type_address_by_value_address[(size_t)val] = (size_t)type;
     profile.allocs.emplace_back(RawAlloc{
         type,

--- a/src/gc-alloc-profiler.h
+++ b/src/gc-alloc-profiler.h
@@ -23,7 +23,7 @@ struct RawAllocResults {
     size_t num_frees;
 };
 
-JL_DLLEXPORT void jl_start_alloc_profile(int skip_every);
+JL_DLLEXPORT void jl_start_alloc_profile(double sample_rate);
 JL_DLLEXPORT struct RawAllocResults jl_fetch_alloc_profile(void);
 JL_DLLEXPORT void jl_stop_alloc_profile(void);
 JL_DLLEXPORT void jl_free_alloc_profile(void);

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -42,7 +42,7 @@ macro profile(opts, ex)
     _prof_expr(ex, opts)
 end
 macro profile(ex)
-    _prof_expr(ex, :(sample_rate=1.0))
+    _prof_expr(ex, :(sample_rate=0.0001))
 end
 
 function _prof_expr(expr, opts)

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -42,7 +42,7 @@ macro profile(opts, ex)
     _prof_expr(ex, opts)
 end
 macro profile(ex)
-    _prof_expr(ex, :(skip_every=1000))
+    _prof_expr(ex, :(sample_rate=1.0))
 end
 
 function _prof_expr(expr, opts)
@@ -54,8 +54,8 @@ function _prof_expr(expr, opts)
     end
 end
 
-function start(; skip_every::Int)
-    ccall(:jl_start_alloc_profile, Cvoid, (Cint,), skip_every)
+function start(; sample_rate::Float64)
+    ccall(:jl_start_alloc_profile, Cvoid, (Cdouble,), sample_rate)
 end
 
 function stop()


### PR DESCRIPTION
instead of recording every N allocs.

```
julia> res, prof = Profile.Allocs.@profile sample_rate=0.1 HeapSnapshotParser.parse_snapshot("testdata/empty-repl.heapsnapshot")
(HeapSnapshot, AllocResults)

julia> length(prof.allocs)
293052

julia> res, prof = Profile.Allocs.@profile sample_rate=0.01 HeapSnapshotParser.parse_snapshot("testdata/empty-repl.heapsnapshot")
(HeapSnapshot, AllocResults)

julia> length(prof.allocs)
29051

julia> res, prof = Profile.Allocs.@profile sample_rate=0.001 HeapSnapshotParser.parse_snapshot("testdata/empty-repl.heapsnapshot")
(HeapSnapshot, AllocResults)

julia> length(prof.allocs)
2967

julia> res, prof = Profile.Allocs.@profile sample_rate=0.0001 HeapSnapshotParser.parse_snapshot("testdata/empty-repl.heapsnapshot")
(HeapSnapshot, AllocResults)

julia> length(prof.allocs)
291
```