### PR TITLE
alloc profiler: fetch-based API

### DIFF
--- a/src/gc-alloc-profiler.cpp
+++ b/src/gc-alloc-profiler.cpp
@@ -81,7 +81,17 @@ JL_DLLEXPORT void jl_start_alloc_profile(int skip_every) {
 
 extern "C" {  // Needed since the function doesn't take any arguments.
 
-JL_DLLEXPORT struct RawAllocResults jl_stop_alloc_profile() {
+JL_DLLEXPORT struct RawAllocResults jl_fetch_alloc_profile() {
+    // TODO: check that the results exist
+    return RawAllocResults{
+        g_combined_results.combined_allocs.data(),
+        g_combined_results.combined_allocs.size(),
+        g_combined_results.combined_frees.data(),
+        g_combined_results.combined_frees.size()
+    };
+}
+
+JL_DLLEXPORT void jl_stop_alloc_profile() {
     g_alloc_profile_enabled = false;
 
     // combine allocs
@@ -101,13 +111,6 @@ JL_DLLEXPORT struct RawAllocResults jl_stop_alloc_profile() {
             });
         }
     }
-
-    return RawAllocResults{
-        g_combined_results.combined_allocs.data(),
-        g_combined_results.combined_allocs.size(),
-        g_combined_results.combined_frees.data(),
-        g_combined_results.combined_frees.size()
-    };
 }
 
 JL_DLLEXPORT void jl_free_alloc_profile() {

--- a/src/gc-alloc-profiler.h
+++ b/src/gc-alloc-profiler.h
@@ -24,7 +24,8 @@ struct RawAllocResults {
 };
 
 JL_DLLEXPORT void jl_start_alloc_profile(int skip_every);
-JL_DLLEXPORT struct RawAllocResults jl_stop_alloc_profile(void);
+JL_DLLEXPORT struct RawAllocResults jl_fetch_alloc_profile(void);
+JL_DLLEXPORT void jl_stop_alloc_profile(void);
 JL_DLLEXPORT void jl_free_alloc_profile(void);
 
 void _record_allocated_value(jl_value_t *val, size_t size) JL_NOTSAFEPOINT;

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -49,9 +49,8 @@ function _prof_expr(expr, opts)
     quote
         $start(; $(esc(opts)))
         local res = $(esc(expr))
-        local profile = $stop()
-        $clear()
-        (res, profile)
+        $stop()
+        res
     end
 end
 
@@ -60,13 +59,17 @@ function start(; skip_every::Int)
 end
 
 function stop()
-    raw_results = ccall(:jl_stop_alloc_profile, RawAllocResults, ())
-    decoded_results = decode(raw_results)
-    return decoded_results
+    ccall(:jl_stop_alloc_profile, RawAllocResults, ())
 end
 
 function clear()
     ccall(:jl_free_alloc_profile, Cvoid, ())
+end
+
+function fetch()
+    raw_results = ccall(:jl_fetch_alloc_profile, RawAllocResults, ())
+    decoded_results = decode(raw_results)
+    return decoded_results
 end
 
 # decoded results


### PR DESCRIPTION
Before:
```julia
res, prof = Profile.Allocs.@profile my_func()
```

After:
```julia
res = Profile.Allocs.@profile my_func()
prof = Profile.Allocs.fetch()
Profile.Allocs.clear()
```

This matches `Profile`'s API better, and reflects that the profile results really are a global.