### PR TITLE
alloc profiler: record pool allocs, even though they'll be missing a type

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -1250,6 +1250,9 @@ JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
         next = (jl_taggedvalue_t*)((char*)v + osize);
     }
     p->newpages = next;
+
+    maybe_record_alloc_to_profile(v, 0);
+
     return jl_valueof(v);
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -1226,6 +1226,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
             pg->nfree = 0;
             pg->has_young = 1;
         }
+        maybe_record_alloc_to_profile(v, osize);
         return jl_valueof(v);
     }
     // if the freelist is empty we reuse empty but not freed pages
@@ -1250,9 +1251,7 @@ JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
         next = (jl_taggedvalue_t*)((char*)v + osize);
     }
     p->newpages = next;
-
-    maybe_record_alloc_to_profile(v, 0);
-
+    maybe_record_alloc_to_profile(v, osize);
     return jl_valueof(v);
 }
 


### PR DESCRIPTION
merges onto https://github.com/JuliaLang/julia/pull/42768

touches https://github.com/JuliaLang/julia/issues/43688

## Description

Some allocations go through the `jl_gc_pool_alloc` codepath, which doesn't get type. This PR captures the stacktrace and size from that codepath anyway. The real solution involves possibly changing LLVM codegen to generate code which pass in a type to `jl_gc_pool_alloc`.

The alloc profiler decoder will mark these as having type `UnknownType`.

## Evaluation

Experimentation on https://github.com/vilterp/HeapSnapshotParser.jl/blob/master/test/runtests.jl shows it's only picking up an additional 1% of allocs:

```julia
# this PR
julia> res = Profile.Allocs.@profile sample_rate=0.01 HeapSnapshotParser.parse_snapshot("testdata/empty-repl.heapsnapshot")
julia> prof = Profile.Allocs.fetch()
julia> num_allocs = length(prof.allocs)
29605

# base alloc profiler
julia> res = Profile.Allocs.@profile sample_rate=0.01 HeapSnapshotParser.parse_snapshot("testdata/empty-repl.heapsnapshot")
julia> prof = Profile.Allocs.fetch()
julia> num_allocs = length(prof.allocs)
29335

julia> 29335.0 / 29605.0
0.990879918932612
```

A larger proprietary codebase was showing ~10%.