### PR TITLE
alloc profile: print percentage of allocs missed

### DIFF
--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -119,9 +119,6 @@ function fetch()
     raw_results = ccall(:jl_fetch_alloc_profile, RawAllocResults, ())
     decoded_results = decode(raw_results)
 
-    @show(length(decoded_results.allocs))
-    @show(_g_expected_sampled_allocs[])
-
     missed_allocs = _g_expected_sampled_allocs[] - length(decoded_results.allocs)
     missed_percentage = round(Int, missed_allocs / _g_expected_sampled_allocs[] * 100)
     @warn("The allocation profiler is not fully implemented, and missed $(missed_percentage)% " *

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -91,17 +91,13 @@ function stop()
 
     gc_num_after = Base.gc_num()
     gc_diff = Base.GC_Diff(gc_num_after, g_gc_num[])
-    println("gc_diff: $gc_diff")
     alloc_count = Base.gc_alloc_count(gc_diff)
-    println("adding alloc_count: $alloc_count")
     g_total_allocs[] = g_total_allocs[] + alloc_count
 
     # TODO: ugh, fetch has side effects
     raw_results = ccall(:jl_fetch_alloc_profile, RawAllocResults, ())
     num_sampled = raw_results.num_allocs
-    println("num sampled $num_sampled; sample_rate: $(g_sample_rate[])")
     estimated_total = round(Int, Float64(num_sampled) / g_sample_rate[])
-    println("adding estimated_total: $estimated_total")
 
     g_estimated_total_allocs[] = g_estimated_total_allocs[] + estimated_total
 end


### PR DESCRIPTION
merges into [#42768](https://github.com/JuliaLang/julia/pull/42768)

Print out the number of allocs missed by the profile, to give us a handle on how big of a problem https://github.com/JuliaLang/julia/issues/43688 is.

Uses the same counters used by `@time`. Multiplies the number of sampled allocs by the sample rate to see how many the alloc profiler would have seen, if the sample rate was 1.

Q: I did this entirely in Julia-land, but it may be cleaner to do on the existing structs in C++-land, to avoid introducing more global variables. Not sure.