### PR TITLE
alloc profile: record string allocs

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -508,6 +508,7 @@ JL_DLLEXPORT jl_value_t *jl_alloc_string(size_t len)
         s = jl_gc_big_alloc(ptls, allocsz);
     }
     jl_set_typeof(s, jl_string_type);
+    maybe_record_alloc_to_profile(s, len);
     *(size_t*)s = len;
     jl_string_data(s)[len] = 0;
     return s;

--- a/stdlib/Profile/src/Allocs.jl
+++ b/stdlib/Profile/src/Allocs.jl
@@ -107,6 +107,7 @@ function clear()
     ccall(:jl_free_alloc_profile, Cvoid, ())
 
     _g_expected_sampled_allocs[] = 0
+    return nothing
 end
 
 """

--- a/stdlib/Profile/test/allocs.jl
+++ b/stdlib/Profile/test/allocs.jl
@@ -106,5 +106,14 @@ end
     @test length(Allocs.fetch().allocs) > 10
 
     Allocs.clear()
+end
 
+@testset "alloc profiler catches strings" begin
+    Allocs.@profile sample_rate=1 "$(rand())"
+
+    prof = Allocs.fetch()
+    Allocs.clear()
+
+    @test length(prof.allocs) >= 1
+    @test length([a for a in prof.allocs if a.type == String]) >= 1
 end


### PR DESCRIPTION
This calls directly into gc_pool_alloc, so we were missing it. Knocks a couple percentage points off of the missed alloc percentage.