### PR TITLE
alloc profiler: capture `managed_malloc` and `managed_realloc`

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -3552,6 +3552,7 @@ JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz)
     SetLastError(last_error);
 #endif
     errno = last_errno;
+    maybe_record_alloc_to_profile(b, sz);
     return b;
 }
 
@@ -3593,7 +3594,7 @@ static void *gc_managed_realloc_(jl_ptls_t ptls, void *d, size_t sz, size_t olds
     SetLastError(last_error);
 #endif
     errno = last_errno;
-
+    maybe_record_alloc_to_profile(b, sz);
     return b;
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -3552,7 +3552,8 @@ JL_DLLEXPORT void *jl_gc_managed_malloc(size_t sz)
     SetLastError(last_error);
 #endif
     errno = last_errno;
-    maybe_record_alloc_to_profile(b, sz);
+    // jl_gc_managed_malloc is currently always used for allocating array buffers.
+    maybe_record_alloc_to_profile(b, sz, jl_buff_tag);
     return b;
 }
 

--- a/src/gc.c
+++ b/src/gc.c
@@ -3595,7 +3595,7 @@ static void *gc_managed_realloc_(jl_ptls_t ptls, void *d, size_t sz, size_t olds
     SetLastError(last_error);
 #endif
     errno = last_errno;
-    maybe_record_alloc_to_profile(b, sz);
+    maybe_record_alloc_to_profile(b, sz, jl_gc_unknown_type_tag);
     return b;
 }
 


### PR DESCRIPTION
Merges into https://github.com/JuliaLang/julia/pull/43868

Catches a few hundred new allocs on `HeapSnapshotParser`

TODO:
- [x] make sure it's not double counting