### PR TITLE
alloc profile: inline gc_pool_alloc (with another wrapper)

### DIFF
--- a/src/array.c
+++ b/src/array.c
@@ -500,6 +500,8 @@ JL_DLLEXPORT jl_value_t *jl_alloc_string(size_t len)
         int pool_id = jl_gc_szclass_align8(allocsz);
         jl_gc_pool_t *p = &ptls->heap.norm_pools[pool_id];
         int osize = jl_gc_sizeclasses[pool_id];
+        // We call `jl_gc_pool_alloc_wrapper` instead of `jl_gc_pool_alloc` to avoid double-counting in
+        // the Allocations Profiler. (See https://github.com/JuliaLang/julia/pull/43868 for more details.)
         s = jl_gc_pool_alloc_wrapper(ptls, (char*)p - (char*)ptls, osize);
     }
     else {

--- a/src/array.c
+++ b/src/array.c
@@ -500,7 +500,7 @@ JL_DLLEXPORT jl_value_t *jl_alloc_string(size_t len)
         int pool_id = jl_gc_szclass_align8(allocsz);
         jl_gc_pool_t *p = &ptls->heap.norm_pools[pool_id];
         int osize = jl_gc_sizeclasses[pool_id];
-        s = jl_gc_pool_alloc_inner(ptls, (char*)p - (char*)ptls, osize);
+        s = jl_gc_pool_alloc_wrapper(ptls, (char*)p - (char*)ptls, osize);
     }
     else {
         if (allocsz < sz) // overflow in adding offs, size was "negative"

--- a/src/gc.c
+++ b/src/gc.c
@@ -1196,19 +1196,9 @@ static NOINLINE jl_taggedvalue_t *add_page(jl_gc_pool_t *p) JL_NOTSAFEPOINT
     return fl;
 }
 
-// instrumented version of jl_gc_pool_alloc_inner called into by LLVM-generated code
-JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
-                                          int osize)
-{
-    jl_value_t *val = jl_gc_pool_alloc_inner(ptls, pool_offset, osize);
-
-    maybe_record_alloc_to_profile(val, osize, jl_gc_unknown_type_tag);
-    return val;
-}
-
 // Size includes the tag and the tag is not cleared!!
-jl_value_t *jl_gc_pool_alloc_inner(jl_ptls_t ptls, int pool_offset,
-                                   int osize)
+static inline jl_value_t *jl_gc_pool_alloc_inner(jl_ptls_t ptls, int pool_offset,
+                                          int osize)
 {
     // Use the pool offset instead of the pool address as the argument
     // to workaround a llvm bug.
@@ -1261,6 +1251,21 @@ jl_value_t *jl_gc_pool_alloc_inner(jl_ptls_t ptls, int pool_offset,
     }
     p->newpages = next;
     return jl_valueof(v);
+}
+
+// instrumented version of jl_gc_pool_alloc_inner called into by LLVM-generated code
+JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
+                                          int osize)
+{
+    jl_value_t *val = jl_gc_pool_alloc_inner(ptls, pool_offset, osize);
+
+    maybe_record_alloc_to_profile(val, osize, jl_gc_unknown_type_tag);
+    return val;
+}
+
+jl_value_t *jl_gc_pool_alloc_wrapper(jl_ptls_t ptls, int pool_offset,
+                                     int osize) {
+    return jl_gc_pool_alloc_inner(ptls, pool_offset, osize);
 }
 
 int jl_gc_classify_pools(size_t sz, int *osize)

--- a/src/gc.c
+++ b/src/gc.c
@@ -1263,8 +1263,10 @@ JL_DLLEXPORT jl_value_t *jl_gc_pool_alloc(jl_ptls_t ptls, int pool_offset,
     return val;
 }
 
-jl_value_t *jl_gc_pool_alloc_wrapper(jl_ptls_t ptls, int pool_offset,
-                                     int osize) {
+// This wrapper exists only to prevent `jl_gc_pool_alloc_inner` from being inlined into
+// its callers. We provide an external-facing interface for callers, and inline `jl_gc_pool_alloc_inner`
+// into this. (See https://github.com/JuliaLang/julia/pull/43868 for more details.)
+jl_value_t *jl_gc_pool_alloc_wrapper(jl_ptls_t ptls, int pool_offset, int osize) {
     return jl_gc_pool_alloc_inner(ptls, pool_offset, osize);
 }
 

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -228,7 +228,7 @@ extern jl_array_t *jl_all_methods JL_GLOBALLY_ROOTED;
 JL_DLLEXPORT extern int jl_lineno;
 JL_DLLEXPORT extern const char *jl_filename;
 
-jl_value_t *jl_gc_pool_alloc_inner(jl_ptls_t ptls, int pool_offset,
+jl_value_t *jl_gc_pool_alloc_wrapper(jl_ptls_t ptls, int pool_offset,
                                    int osize);
 JL_DLLEXPORT jl_value_t *jl_gc_big_alloc(jl_ptls_t ptls, size_t allocsz);
 JL_DLLEXPORT int jl_gc_classify_pools(size_t sz, int *osize);
@@ -357,7 +357,7 @@ STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
         int pool_id = jl_gc_szclass(allocsz);
         jl_gc_pool_t *p = &ptls->heap.norm_pools[pool_id];
         int osize = jl_gc_sizeclasses[pool_id];
-        v = jl_gc_pool_alloc_inner(ptls, (char*)p - (char*)ptls, osize);
+        v = jl_gc_pool_alloc_wrapper(ptls, (char*)p - (char*)ptls, osize);
     }
     else {
         if (allocsz < sz) // overflow in adding offs, size was "negative"

--- a/src/julia_internal.h
+++ b/src/julia_internal.h
@@ -357,6 +357,8 @@ STATIC_INLINE jl_value_t *jl_gc_alloc_(jl_ptls_t ptls, size_t sz, void *ty)
         int pool_id = jl_gc_szclass(allocsz);
         jl_gc_pool_t *p = &ptls->heap.norm_pools[pool_id];
         int osize = jl_gc_sizeclasses[pool_id];
+        // We call `jl_gc_pool_alloc_wrapper` instead of `jl_gc_pool_alloc` to avoid double-counting in
+        // the Allocations Profiler. (See https://github.com/JuliaLang/julia/pull/43868 for more details.)
         v = jl_gc_pool_alloc_wrapper(ptls, (char*)p - (char*)ptls, osize);
     }
     else {


### PR DESCRIPTION
merges into https://github.com/JuliaLang/julia/pull/43868

This inlines the new shared implementation of `jl_gc_pool_alloc` into the old callers, so that there's no added overhead from the extra function call.

Changes the graph to this:

<img width="738" alt="call diagram" src="https://user-images.githubusercontent.com/1582097/151675326-1ae80230-9312-4f1c-83bd-2339170fa463.png">

*: instrumented; red: currently missed; green: newly introduced function

<details>
<summary>graphviz</summary>

```graphviz
digraph G {
  node [shape=box];

  generated_code [label="<generated code>"];

  new_array;
  jl_gc_alloc_string [label="jl_gc_alloc_string *"];
  jl_gc_alloc [label="jl_gc_alloc *"];
  jl_gc_managed_malloc [label="jl_managed_malloc *"]; // https://github.com/vilterp/julia/pull/20
  jl_gc_pool_alloc;
  jl_gc_pool_alloc [fillcolor=lightgreen style=filled label="jl_gc_pool_alloc *"];
  jl_gc_big_alloc;

  {
    rank=same;
    jl_gc_managed_malloc;
    jl_gc_pool_alloc_inner;
    jl_gc_big_alloc;
  }

  generated_code -> jl_gc_alloc_string;
  generated_code -> new_array;
  generated_code -> jl_gc_alloc;
  generated_code -> jl_gc_big_alloc [color=red];
  generated_code -> jl_gc_pool_alloc;
  jl_gc_pool_alloc -> jl_gc_pool_alloc_inner;

  jl_gc_alloc -> jl_gc_pool_alloc_inner;
  jl_gc_alloc -> jl_gc_big_alloc;
  new_array -> jl_gc_alloc;
  new_array -> jl_gc_managed_malloc;
  jl_gc_alloc_string -> jl_gc_pool_alloc_inner;
  jl_gc_alloc_string -> jl_gc_big_alloc;
}
```
</details>

