### PR TITLE
switch to raw types to avoid deadlock

### DIFF
--- a/base/gcutils.jl
+++ b/base/gcutils.jl
@@ -116,6 +116,12 @@ function take_heap_snapshot(io)
     ccall(:jl_gc_take_heap_snapshot, Cvoid, (Ptr{Cvoid},), (io::IOStream).handle::Ptr{Cvoid})
 end
 
+# function take_heap_snapshot(path::String)
+#     open(path, "w") do f
+#         take_heap_snapshot(f)
+#     end
+# end
+
 """
     GC.enable_finalizers(on::Bool)
 

--- a/src/gc-heap-snapshot.cpp
+++ b/src/gc-heap-snapshot.cpp
@@ -224,16 +224,7 @@ size_t record_node_to_gc_snapshot(jl_value_t *a) JL_NOTSAFEPOINT {
                 ? jl_array_nbytes((jl_array_t*)a)
                 : (size_t)jl_datatype_size(type);
 
-            // print full type
-            // TODO(PR): Is it possible to use a variable size string here, instead??
-            ios_t str_;
-            ios_mem(&str_, 1048576);  // 1 MiB
-            JL_STREAM* str = (JL_STREAM*)&str_;
-
-            jl_static_show(str, (jl_value_t*)type);
-
-            name = string((const char*)str_.buf, str_.size);
-            ios_close(&str_);
+            name = jl_symbol_name(type->name->name);
         }
     }
 
@@ -295,6 +286,10 @@ bool _fieldpath_for_slot_helper(
             out.push_back(inlineallocd_field_type_t(objtype, field_name));
             return true;
         }
+        // if ((size_t) field_type < 1e8) {
+        //     jl_printf(JL_STDERR, "invalid field type\n");
+        //     continue;
+        // }
         // If the field is an inline-allocated struct
         if (jl_stored_inline((jl_value_t*)field_type)) {
             bool found = _fieldpath_for_slot_helper(out, field_type, fieldaddr, slot);


### PR DESCRIPTION
Printing the full types was sometimes causing a deadlock; switch to a simpler representation