### PR TITLE
make new timing change backward-compatible

### DIFF
--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -97,16 +97,50 @@ const _finished_timings = Timing[]
 # because we create a new node for duplicates.)
 const _timings = Timing[]
 
+# ROOT() is an empty function used as the top-level Timing node to measure all time spent
+# *not* in type inference during a given recording trace. It is used as a "dummy" node.
+function ROOT() end
+const ROOTmi = Core.Compiler.specialize_method(
+    first(Core.Compiler.methods(ROOT)), Tuple{typeof(ROOT)}, Core.svec())
+"""
+    Core.Compiler.reset_timings()
+Empty out the previously recorded type inference timings (`Core.Compiler._timings`), and
+start the ROOT() timer again. `ROOT()` measures all time spent _outside_ inference.
+
+DEPRECATED: this will be removed; use `clear_and_fetch_timings` instead.
+"""
+function reset_timings()
+    empty!(_timings)
+    push!(_timings, Timing(
+        # The MethodInstance for ROOT(), and default empty values for other fields.
+        InferenceFrameInfo(ROOTmi, 0x0, Any[], Any[Core.Const(ROOT)], 1),
+        _time_ns()))
+    return nothing
+end
+reset_timings()
+
+# (This is split into a function so that it can be called both in this module, at the top
+# of `enter_new_timer()`, and once at the Very End of the operation, by whoever started
+# the operation and called `reset_timings()`.)
+# NOTE: the @inline annotations here are not to make it faster, but to reduce the gap between
+# timer manipulations and the tasks we're timing.
+@inline function close_current_timer()
+    stop_time = _time_ns()
+    parent_timer = _timings[end]
+    accum_time = stop_time - parent_timer.cur_start_time
+
+    # Add in accum_time ("modify" the immutable struct)
+    @inbounds begin
+        _timings[end].time += accum_time
+    end
+    return nothing
+end
+
 @inline function enter_new_timer(frame)
     # Very first thing, stop the active timer: get the current time and add in the
     # time since it was last started to its aggregate exclusive time.
-    if length(_timings) > 0
-        stop_time = _time_ns()
-        parent_timer = _timings[end]
-        accum_time = stop_time - parent_timer.cur_start_time
-
-        # Add in accum_time
-        parent_timer.time += accum_time
+    if length(_timings) > 0 || (length(_timings) === 1 && _timings[1] === ROOTmi)
+        close_current_timer()
     end
 
     # Start the new timer right before returning

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -117,7 +117,6 @@ function reset_timings()
         _time_ns()))
     return nothing
 end
-reset_timings()
 
 # (This is split into a function so that it can be called both in this module, at the top
 # of `enter_new_timer()`, and once at the Very End of the operation, by whoever started
@@ -129,7 +128,7 @@ reset_timings()
     parent_timer = _timings[end]
     accum_time = stop_time - parent_timer.cur_start_time
 
-    # Add in accum_time ("modify" the immutable struct)
+    # Add in accum_time
     @inbounds begin
         _timings[end].time += accum_time
     end
@@ -139,7 +138,7 @@ end
 @inline function enter_new_timer(frame)
     # Very first thing, stop the active timer: get the current time and add in the
     # time since it was last started to its aggregate exclusive time.
-    if length(_timings) > 0 || (length(_timings) > 1 && _timings[1] === ROOTmi)
+    if length(_timings) > 0
         close_current_timer()
     end
 

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -47,6 +47,9 @@ end
 
 _typeinf_identifier(frame::InferenceFrameInfo) = frame
 
+_typeinf_frame_linfo(frame::Core.Compiler.InferenceState) = frame.linfo
+_typeinf_frame_linfo(frame::InferenceFrameInfo) = frame.mi
+
 """
     Core.Compiler.Timings.Timing(mi_info, start_time, ...)
 
@@ -164,13 +167,13 @@ end
     # Finish the new timer
     stop_time = _time_ns()
 
-    expected_mi_info = _typeinf_identifier(_expected_frame_)
+    expected_linfo = _typeinf_frame_linfo(_expected_frame_)
 
     # Grab the new timer again because it might have been modified in _timings
     # (since it's an immutable struct)
     # And remove it from the current timings stack
     new_timer = pop!(_timings)
-    Core.Compiler.@assert new_timer.mi_info.mi === expected_mi_info.mi
+    Core.Compiler.@assert new_timer.mi_info.mi === expected_linfo
 
     # check for two cases: normal case & backcompat case
     is_profile_root_normal = length(_timings) === 0

--- a/base/compiler/typeinfer.jl
+++ b/base/compiler/typeinfer.jl
@@ -139,7 +139,7 @@ end
 @inline function enter_new_timer(frame)
     # Very first thing, stop the active timer: get the current time and add in the
     # time since it was last started to its aggregate exclusive time.
-    if length(_timings) > 0 || (length(_timings) === 1 && _timings[1] === ROOTmi)
+    if length(_timings) > 0 || (length(_timings) > 1 && _timings[1] === ROOTmi)
         close_current_timer()
     end
 
@@ -173,7 +173,10 @@ end
     new_timer = pop!(_timings)
     Core.Compiler.@assert new_timer.mi_info.mi === expected_mi_info.mi
 
-    is_profile_root = length(_timings) === 0
+    # check for two cases: normal case & backcompat case
+    is_profile_root_normal = length(_timings) === 0
+    is_profile_root_backcompat = length(_timings) === 1 && _timings[1] === ROOTmi
+    is_profile_root = is_profile_root_normal || is_profile_root_backcompat
 
     accum_time = stop_time - new_timer.cur_start_time
     # Add in accum_time ("modify" the immutable struct)

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3479,9 +3479,6 @@ end
         @eval M1.g(2, 3.0)
     end
     @test timing1 isa Vector{Core.Compiler.Timings.Timing}
-    
-    println("timing ", timing1)
-    
     # The last two functions to be inferred should be `i` and `i2`, inferred at runtime with
     # their concrete types.
     @test sort([mi_info.mi.def.name for (time,mi_info) in flatten_times(timing1)[end-1:end]]) == [:i, :i2]

--- a/test/compiler/inference.jl
+++ b/test/compiler/inference.jl
@@ -3479,6 +3479,9 @@ end
         @eval M1.g(2, 3.0)
     end
     @test timing1 isa Vector{Core.Compiler.Timings.Timing}
+    
+    println("timing ", timing1)
+    
     # The last two functions to be inferred should be `i` and `i2`, inferred at runtime with
     # their concrete types.
     @test sort([mi_info.mi.def.name for (time,mi_info) in flatten_times(timing1)[end-1:end]]) == [:i, :i2]


### PR DESCRIPTION
Merges into https://github.com/JuliaLang/julia/pull/47615, attempting to make it backward-compatible

TODO:
- [ ] print deprecation warning (`println` and `@warn` are undefined in the compiler)